### PR TITLE
feat: add contract and payment interfaces for PDF generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,8 @@ build/
 
 # Database files
 data/
+!shared/data/
+!shared/data/**
 *.db
 *.sqlite
 *.sqlite3

--- a/shared/data/contract-repository.ts
+++ b/shared/data/contract-repository.ts
@@ -1,0 +1,21 @@
+export interface Contract {
+  id: number;
+  member_name: string;
+  phone: string;
+  email?: string;
+  plan: string;
+  price: number;
+  start_at: string;
+  end_at: string;
+  status: string;
+  created_at?: string;
+  created_by?: string;
+  kiosk_id: string;
+  locker_id: number;
+  rfid_card: string;
+  backup_card?: string;
+  notes?: string;
+}
+
+// Placeholder repository class for dependency mocks.
+export class ContractRepository {}

--- a/shared/data/payment-repository.ts
+++ b/shared/data/payment-repository.ts
@@ -1,0 +1,13 @@
+export interface Payment {
+  id: number;
+  contract_id: number;
+  amount: number;
+  method: string;
+  paid_at: string;
+  reference?: string;
+  notes?: string;
+  created_by?: string;
+}
+
+// Placeholder repository class for dependency mocks.
+export class PaymentRepository {}

--- a/shared/package.json
+++ b/shared/package.json
@@ -11,11 +11,13 @@
   },
   "dependencies": {
     "sqlite3": "^5.1.6",
-    "fs-extra": "^11.1.1"
+    "fs-extra": "^11.1.1",
+    "pdfkit": "^0.17.1"
   },
   "devDependencies": {
     "@types/node": "^20.8.0",
     "@types/fs-extra": "^11.0.4",
+    "@types/pdfkit": "^0.17.2",
     "typescript": "^5.2.2",
     "vitest": "^3.2.4"
   },

--- a/shared/services/__tests__/pdf-service.test.ts
+++ b/shared/services/__tests__/pdf-service.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { PDFService, ContractPDFData, PDFGenerationOptions } from '../pdf-service';
+import { Contract } from '../../data/contract-repository';
+import { Payment } from '../../data/payment-repository';
 
 describe('PDFService', () => {
   let pdfService: PDFService;
@@ -7,13 +9,14 @@ describe('PDFService', () => {
 
   beforeEach(() => {
     pdfService = new PDFService();
-    mockContract = {
+
+    const baseContract: Contract = {
       id: 1,
       member_name: 'John Doe',
       phone: '+90 555 123 4567',
       email: 'john.doe@example.com',
       plan: 'premium',
-      price: 450.00,
+      price: 450.0,
       start_at: '2024-01-01',
       end_at: '2024-07-01',
       status: 'active',
@@ -23,9 +26,13 @@ describe('PDFService', () => {
       locker_id: 5,
       rfid_card: 'RFID123456',
       backup_card: 'RFID789012',
-      notes: 'Premium member with backup card',
-      total_paid: 225.00,
-      remaining_balance: 225.00
+      notes: 'Premium member with backup card'
+    };
+
+    mockContract = {
+      ...baseContract,
+      total_paid: 225.0,
+      remaining_balance: 225.0
     };
   });
 
@@ -42,20 +49,22 @@ describe('PDFService', () => {
     });
 
     it('should generate a PDF with payment history when includePayments is true', async () => {
+      const payments: Payment[] = [
+        {
+          id: 1,
+          contract_id: 1,
+          amount: 225.0,
+          method: 'card',
+          paid_at: '2024-01-01T10:00:00Z',
+          reference: 'PAY123456',
+          notes: 'Initial payment',
+          created_by: 'admin'
+        }
+      ];
+
       const contractWithPayments: ContractPDFData = {
         ...mockContract,
-        payments: [
-          {
-            id: 1,
-            contract_id: 1,
-            amount: 225.00,
-            method: 'card',
-            paid_at: '2024-01-01T10:00:00Z',
-            reference: 'PAY123456',
-            notes: 'Initial payment',
-            created_by: 'admin'
-          }
-        ]
+        payments
       };
 
       const options: PDFGenerationOptions = {
@@ -141,32 +150,34 @@ describe('PDFService', () => {
     });
 
     it('should handle contracts with multiple payments', async () => {
+      const payments: Payment[] = [
+        {
+          id: 1,
+          contract_id: 1,
+          amount: 150.0,
+          method: 'cash',
+          paid_at: '2024-01-01T10:00:00Z',
+          reference: 'CASH001',
+          notes: 'Initial payment',
+          created_by: 'admin'
+        },
+        {
+          id: 2,
+          contract_id: 1,
+          amount: 75.0,
+          method: 'card',
+          paid_at: '2024-02-01T10:00:00Z',
+          reference: 'CARD002',
+          notes: 'Second payment',
+          created_by: 'admin'
+        }
+      ];
+
       const contractWithMultiplePayments: ContractPDFData = {
         ...mockContract,
-        payments: [
-          {
-            id: 1,
-            contract_id: 1,
-            amount: 150.00,
-            method: 'cash',
-            paid_at: '2024-01-01T10:00:00Z',
-            reference: 'CASH001',
-            notes: 'Initial payment',
-            created_by: 'admin'
-          },
-          {
-            id: 2,
-            contract_id: 1,
-            amount: 75.00,
-            method: 'card',
-            paid_at: '2024-02-01T10:00:00Z',
-            reference: 'CARD002',
-            notes: 'Second payment',
-            created_by: 'admin'
-          }
-        ],
-        total_paid: 225.00,
-        remaining_balance: 225.00
+        payments,
+        total_paid: 225.0,
+        remaining_balance: 225.0
       };
 
       const options: PDFGenerationOptions = {


### PR DESCRIPTION
## Summary
- define `Contract` and `Payment` interfaces in repository layer
- update PDF service tests to leverage the new interfaces
- expose pdfkit dependency for shared workspace

## Testing
- `npx vitest run shared/services/__tests__/pdf-service.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68ab865864308329959ddf8bf63baf86