### PR TITLE
feat(ui): Enlarge kiosk buttons, refactor styles, and enable scrolling

### DIFF
--- a/app/kiosk/src/ui/static/styles-simple.css
+++ b/app/kiosk/src/ui/static/styles-simple.css
@@ -504,13 +504,6 @@ html, body {
 }
 
 /* Tile Content - Large, readable numbers and status (Requirements 5.1, 5.2, 5.3) */
-.locker-number {
-    font-size: 1.8rem;
-    font-weight: 800;
-    margin-bottom: 6px;
-    text-shadow: 0 1px 2px rgba(0, 0, 0, 0.3);
-    line-height: 1;
-}
 
 .locker-status {
     font-size: 0.9rem;
@@ -1328,6 +1321,7 @@ html, body {
 
 .session-container {
     width: 100%;
+    height: 100%;
     padding: 1.5rem;
     display: flex;
     flex-direction: column;
@@ -1468,8 +1462,8 @@ html, body {
     margin: 0;
 }
 
-.locker-number {
-    font-size: 12rem;
+#session-screen .locker-number {
+    font-size: 15rem;
     font-weight: bold;
     color: #c9d1d9;
     line-height: 1;


### PR DESCRIPTION
This commit addresses the user's requests to make the UI elements on the kiosk screen larger, more readable, and more user-friendly.

The following changes were made:
- The locker selection buttons on the session screen have been made larger.
- The font size of the locker number has been increased to cover the entire button, and all margins and paddings have been removed from the tile.
- The buttons on the owned-decision screen now stack vertically and fill the width of the screen.
- The inline styles for the owned-decision screen have been moved to `styles-simple.css`.
- The locker grid on the session screen is now scrollable if it overflows, with touch-friendly scrolling.