### PR TITLE
Fix panel health check in system monitor

### DIFF
--- a/scripts/deployment/system-monitor.sh
+++ b/scripts/deployment/system-monitor.sh
@@ -175,7 +175,7 @@ while true; do
     # Check service health
     GATEWAY_STATUS=$(check_service_health "gateway" "3000" "/health")
     KIOSK_STATUS=$(check_service_health "kiosk" "3002" "/health")
-    PANEL_STATUS=$(check_service_health "panel" "3001" "")
+    PANEL_STATUS=$(check_service_health "panel" "3001" "/health")
     
     # Update status file with service status
     echo "GATEWAY_STATUS=$GATEWAY_STATUS" >> "$STATUS_FILE"


### PR DESCRIPTION
The system monitor script was using the wrong endpoint to check the health of the panel service. It was checking `/` instead of `/health`.

This change updates the `system-monitor.sh` script to use the correct `/health` endpoint for the panel service, preventing false negatives and unnecessary service restarts.