### PR TITLE
Fix: Make relay count dynamic on relay.html

### DIFF
--- a/app/panel/src/views/relay.html
+++ b/app/panel/src/views/relay.html
@@ -437,27 +437,36 @@
 
     <script>
         let selectedRelays = new Set();
+        let totalRelays = 0;
 
         // Initialize the page
-        document.addEventListener('DOMContentLoaded', function() {
-            generateRelayGrid();
+        document.addEventListener('DOMContentLoaded', async function() {
+            try {
+                const response = await fetch('/api/relay/total');
+                const data = await response.json();
+                totalRelays = data.totalRelays;
+            } catch (error) {
+                console.error('Error fetching total relays:', error);
+                totalRelays = 30; // Fallback to 30 on error
+            }
+            generateRelayGrid(totalRelays);
             checkStatus();
         });
 
-        function generateRelayGrid() {
+        function generateRelayGrid(relayCount) {
             const grid = document.getElementById('relay-grid');
             grid.innerHTML = '';
             
-            for (let i = 1; i <= 30; i++) {
+            for (let i = 1; i <= relayCount; i++) {
                 const button = document.createElement('div');
                 button.className = 'relay-button';
                 button.innerHTML = `<div>Röle ${i}</div>`;
-                button.onclick = () => toggleRelay(i, button);
+                button.onclick = (event) => toggleRelay(i, button, event);
                 grid.appendChild(button);
             }
         }
 
-        async function toggleRelay(relayNumber, button) {
+        async function toggleRelay(relayNumber, button, event) {
             // Check if this is a selection toggle (Ctrl/Cmd key held) or direct activation
             if (event.ctrlKey || event.metaKey) {
                 // Selection mode - just toggle selection
@@ -679,7 +688,7 @@
                 if (trimmed.includes('-')) {
                     // Range like "1-5"
                     const [start, end] = trimmed.split('-').map(n => parseInt(n.trim()));
-                    if (start && end && start <= end && start >= 1 && end <= 30) {
+                    if (start && end && start <= end && start >= 1 && end <= totalRelays) {
                         for (let i = start; i <= end; i++) {
                             relays.push(i);
                         }
@@ -687,7 +696,7 @@
                 } else {
                     // Single number
                     const num = parseInt(trimmed);
-                    if (num >= 1 && num <= 30) {
+                    if (num >= 1 && num <= totalRelays) {
                         relays.push(num);
                     }
                 }


### PR DESCRIPTION
The relay control screen (relay.html) was previously hardcoded to display 30 relays, regardless of the actual hardware configuration. This caused an issue where users with more than 30 relays could not see or control them from the UI.

This commit fixes the issue by:
1.  **Backend:**
    - Modifying `app/panel/src/routes/relay-routes.ts` to dynamically calculate the total number of relays from the `hardware.relay_cards` in `config/system.json`.
    - Replacing the hardcoded `30` in the API endpoint validation with the new dynamic count.
    - Adding a new API endpoint `/api/relay/total` to provide the total relay count to the frontend.

2.  **Frontend:**
    - Updating `app/panel/src/views/relay.html` to fetch the total relay count from the new `/api/relay/total` endpoint on page load.
    - Modifying the JavaScript to dynamically generate the relay buttons based on the fetched count.
    - Updating the input validation for bulk relay operations to use the dynamic count.

This change ensures that the relay control screen accurately reflects the hardware configuration, making all configured relays accessible to the user.