### PR TITLE
Fix: Implement dynamic relay mapping and limits

### DIFF
--- a/app/gateway/src/routes/admin.ts
+++ b/app/gateway/src/routes/admin.ts
@@ -4,7 +4,7 @@
  */
 
 import { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify';
-import { configManager } from '../../../shared/services/config-manager';
+import { configManager } from '@eform/shared/services/config-manager';
 
 interface AdminLockerOpenRequest {
   Body: {


### PR DESCRIPTION
This commit resolves two related issues that caused errors when using more than 30-32 relays:
1.  The number of usable relays was hardcoded in several parts of the admin panel.
2.  The logic for activating relays assumed sequential hardware addresses, causing errors for non-sequential configurations.

The following changes were made:

1.  **`app/panel/src/routes/relay-routes.ts`**:
    - Refactored the `SimpleRelayService` to accept the hardware configuration.
    - Implemented a new logic in `activateRelay` to correctly map a global relay number to the specific `slave_address` and `coilAddress` by iterating through the `relay_cards` array. This fixes the 500 error for relays > 32.
    - Replaced hardcoded limits with a dynamic count calculated from the configuration.
    - Added a `/api/relay/total` endpoint to provide the relay count to the frontend.

2.  **`app/panel/src/routes/locker-routes.ts`**:
    - Replaced hardcoded validation limits with the dynamic relay count from the configuration.

3.  **`app/gateway/src/routes/admin.ts`**:
    - Replaced hardcoded validation limits in the Gateway service with the dynamic relay count from the configuration. This was the root cause of the 500 error reported by the user.

4.  **`app/panel/src/views/relay.html`**:
    - The frontend now fetches the total relay count from the new API endpoint and generates the UI dynamically.

5.  **Build Fix**:
    - All relative import paths for the `@eform/shared` module have been updated to use workspace imports (e.g., `@eform/shared/services/config-manager`) to ensure a successful build.

These changes make the relay and locker systems fully dynamic and adaptable to the hardware configuration specified in `config/system.json`.