### PR TITLE
Fix: Implement dynamic relay mapping and limits

### DIFF
--- a/app/gateway/src/index.ts
+++ b/app/gateway/src/index.ts
@@ -16,7 +16,8 @@ if (!process.env.EFORM_DB_PATH) {
 
 import Fastify from "fastify";
 import cookie from "@fastify/cookie";
-import { DatabaseManager } from "../../../shared/database/database-manager.js";
+import { DatabaseManager } from "@eform/shared/database/database-manager";
+import { configManager } from "@eform/shared/services/config-manager";
 import { provisioningRoutes } from "./routes/provisioning.js";
 import { configurationRoutes } from "./routes/configuration.js";
 import { heartbeatRoutes } from "./routes/heartbeat.js";
@@ -106,6 +107,7 @@ fastify.get("/config-panel", async (_request, reply) => {
 // Start server
 const start = async () => {
   try {
+    await configManager.initialize();
     await initializeDatabase();
     const port = parseInt(process.env.PORT || "3000", 10);
     const host = process.env.HOST || "0.0.0.0";

--- a/app/gateway/src/routes/admin.ts
+++ b/app/gateway/src/routes/admin.ts
@@ -24,9 +24,6 @@ interface AdminBulkOpenRequest {
 
 export async function registerAdminRoutes(fastify: FastifyInstance) {
   
-  const hardwareConfig = configManager.getConfiguration().hardware;
-  const totalRelays = hardwareConfig.relay_cards.reduce((sum, card) => sum + (card.enabled ? card.channels : 0), 0);
-
   // Open single locker (admin)
   fastify.post('/api/admin/lockers/:lockerId/open', async (
     request: FastifyRequest<{
@@ -36,6 +33,9 @@ export async function registerAdminRoutes(fastify: FastifyInstance) {
     reply: FastifyReply
   ) => {
     try {
+      const hardwareConfig = configManager.getConfiguration().hardware;
+      const totalRelays = hardwareConfig.relay_cards.reduce((sum, card) => sum + (card.enabled ? card.channels : 0), 0);
+
       const lockerId = parseInt(request.params.lockerId);
       const { staff_user, reason } = request.body;
 
@@ -124,6 +124,9 @@ export async function registerAdminRoutes(fastify: FastifyInstance) {
         });
       }
 
+      const hardwareConfig = configManager.getConfiguration().hardware;
+      const totalRelays = hardwareConfig.relay_cards.reduce((sum, card) => sum + (card.enabled ? card.channels : 0), 0);
+
       // Validate locker IDs
       const invalidIds = locker_ids.filter(id => id < 1 || id > totalRelays);
       if (invalidIds.length > 0) {
@@ -201,6 +204,8 @@ export async function registerAdminRoutes(fastify: FastifyInstance) {
     reply: FastifyReply
   ) => {
     try {
+      const hardwareConfig = configManager.getConfiguration().hardware;
+      const totalRelays = hardwareConfig.relay_cards.reduce((sum, card) => sum + (card.enabled ? card.channels : 0), 0);
       const lockerId = parseInt(request.params.lockerId);
 
       if (!lockerId || lockerId < 1 || lockerId > totalRelays) {


### PR DESCRIPTION
This commit resolves issues where the number of usable relays was hardcoded in several parts of the admin panel, preventing users from accessing all configured hardware.

The following changes were made:

1.  **`app/panel/src/routes/relay-routes.ts`**:
    - Refactored the `SimpleRelayService` to accept the hardware configuration.
    - Implemented a new logic in `activateRelay` to correctly map a global relay number to the specific `slave_address` and `coilAddress` by iterating through the `relay_cards` array. This fixes the 500 error for relays > 32.
    - Replaced hardcoded limits with a dynamic count calculated from the configuration.
    - Added a `/api/relay/total` endpoint to provide the relay count to the frontend.

2.  **`app/panel/src/routes/locker-routes.ts`**:
    - Replaced hardcoded validation limits with the dynamic relay count from the configuration.

3.  **`app/gateway/src/routes/admin.ts`**:
    - Replaced hardcoded validation limits in the Gateway service with the dynamic relay count from the configuration. This was the root cause of the 500 error reported by the user.

4.  **`app/gateway/src/index.ts`**:
    - Added the missing `configManager.initialize()` call to ensure the configuration is loaded before the routes are registered. This fixes a startup crash.

5.  **`app/panel/src/views/relay.html`**:
    - The frontend now fetches the total relay count from the new API endpoint and generates the UI dynamically.

6.  **Build Fix**:
    - All relative import paths for the `@eform/shared` module have been updated to use workspace imports (e.g., `@eform/shared/services/config-manager`) to ensure a successful build.

These changes make the relay and locker systems fully dynamic and adaptable to the hardware configuration specified in `config/system.json`.