### PR TITLE
Ensure gateway database initializes before config manager

### DIFF
--- a/app/gateway/src/index.ts
+++ b/app/gateway/src/index.ts
@@ -109,8 +109,8 @@ const start = async () => {
   try {
     const configPath = path.join(projectRoot, 'config', 'system.json');
     configManager.setConfigPath(configPath);
-    await configManager.initialize();
     await initializeDatabase();
+    await configManager.initialize();
     const port = parseInt(process.env.PORT || "3000", 10);
     const host = process.env.HOST || "0.0.0.0";
 


### PR DESCRIPTION
## Summary
- initialize the gateway database (with migrations path) before starting the shared config manager

## Testing
- npm run start:gateway *(fails: configuration file is invalid JSON, but database migrations now run successfully before the failure)*

------
https://chatgpt.com/codex/tasks/task_e_68c9f72a62a4832999ce35cff281b8d0