### PR TITLE
Temporarily remove open-only decision option

### DIFF
--- a/app/kiosk/src/ui/index.html
+++ b/app/kiosk/src/ui/index.html
@@ -78,7 +78,7 @@
                 <div class="session-container">
                     <div class="session-header-new">
                         <div class="header-left">
-                            <button class="back-button">
+                            <button id="session-close-button" class="back-button" aria-label="Ana ekrana dön">
                                 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M19 12H5M12 19l-7-7 7-7"/></svg>
                             </button>
                             <div class="user-info">

--- a/app/kiosk/src/ui/static/app-simple.js
+++ b/app/kiosk/src/ui/static/app-simple.js
@@ -325,7 +325,7 @@ class SimpleKioskApp {
             'idle-screen', 'session-screen', 'loading-screen', 'error-screen',
             'locker-grid', 'session-timer', 'countdown-value', 'connection-status',
             'loading-text', 'error-text', 'error-description', 'error-recovery',
-            'return-button', 'retry-button',
+            'return-button', 'retry-button', 'session-close-button',
             'feedback-screen', 'feedback-icon', 'feedback-text'
         ];
         
@@ -366,6 +366,12 @@ class SimpleKioskApp {
         // Return to main button
         if (this.elements.returnButton) {
             this.elements.returnButton.addEventListener('click', () => {
+                this.handleReturnToMain();
+            });
+        }
+
+        if (this.elements.sessionCloseButton) {
+            this.elements.sessionCloseButton.addEventListener('click', () => {
                 this.handleReturnToMain();
             });
         }
@@ -746,6 +752,9 @@ class SimpleKioskApp {
             panel.className = 'owned-decision-panel';
 
             panel.innerHTML = `
+                <button id="owned-decision-close" class="owned-decision-close" aria-label="Ana ekrana dön">
+                    <svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="18" y1="6" x2="6" y2="18"></line><line x1="6" y1="6" x2="18" y2="18"></line></svg>
+                </button>
                 <div class="owned-decision-header">
                     <h2 class="owned-decision-title">
                         <span class="owned-decision-title-prefix">Dolabınız</span>
@@ -766,15 +775,6 @@ class SimpleKioskApp {
                             <svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="#F4E8FF" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="9 6 15 12 9 18"></polyline></svg>
                         </div>
                     </button>
-                    <button id="btn-open-only" class="owned-decision-button owned-decision-button--secondary">
-                        <div class="owned-decision-icon" aria-hidden="true">
-                            <svg width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="#38BDF8" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="11" width="18" height="9" rx="2"></rect><path d="M7 11V7a5 5 0 0 1 10 0v4"></path><path d="M12 15v2"></path></svg>
-                        </div>
-                        <div class="owned-decision-copy">
-                            <span class="owned-decision-button-title">Eşyamı almak için aç</span>
-                            <span class="owned-decision-button-subtitle">Dolabınızın kilidi kısa süreliğine açık kalır</span>
-                        </div>
-                    </button>
                 </div>
                 <div id="bottom-info" class="owned-decision-info">Teslim ettiğinizde dolap yeniden kilitlenir ve başkalarının kullanımına açılır.</div>
             `;
@@ -792,26 +792,34 @@ class SimpleKioskApp {
         overlay.style.display = 'flex';
 
         // Wire buttons
-        const btnOpen = document.getElementById('btn-open-only');
         const btnFinish = document.getElementById('btn-finish-release');
+        const btnClose = document.getElementById('owned-decision-close');
 
         const closeOverlay = () => { overlay.style.display = 'none'; };
 
         // Ensure old listeners do not stack
-        btnOpen.replaceWith(btnOpen.cloneNode(true));
-        btnFinish.replaceWith(btnFinish.cloneNode(true));
+        if (btnFinish) {
+            btnFinish.replaceWith(btnFinish.cloneNode(true));
+        }
+        if (btnClose) {
+            btnClose.replaceWith(btnClose.cloneNode(true));
+        }
 
-        const btnOpen2 = document.getElementById('btn-open-only');
         const btnFinish2 = document.getElementById('btn-finish-release');
+        const btnClose2 = document.getElementById('owned-decision-close');
 
-        btnOpen2.addEventListener('click', async () => {
-            closeOverlay();
-            await this.openOwnedLockerOnly(cardId);
-        });
-        btnFinish2.addEventListener('click', async () => {
-            closeOverlay();
-            await this.openAndReleaseLocker(cardId, lockerId);
-        });
+        if (btnFinish2) {
+            btnFinish2.addEventListener('click', async () => {
+                closeOverlay();
+                await this.openAndReleaseLocker(cardId, lockerId);
+            });
+        }
+        if (btnClose2) {
+            btnClose2.addEventListener('click', () => {
+                closeOverlay();
+                this.handleReturnToMain();
+            });
+        }
     }
 
     /**

--- a/app/kiosk/src/ui/static/styles-simple.css
+++ b/app/kiosk/src/ui/static/styles-simple.css
@@ -1400,6 +1400,35 @@ html, body {
     align-items: center;
     gap: clamp(28px, 5.2vh, 64px);
     box-shadow: 0 28px 76px rgba(5, 10, 26, 0.62);
+    position: relative;
+}
+
+
+.owned-decision-close {
+    position: absolute;
+    top: clamp(20px, 3vh, 36px);
+    right: clamp(20px, 3vw, 42px);
+    width: clamp(44px, 5.5vh, 54px);
+    height: clamp(44px, 5.5vh, 54px);
+    border-radius: 50%;
+    border: 1px solid rgba(148, 163, 184, 0.35);
+    background: rgba(15, 23, 42, 0.78);
+    color: #E2E8F0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    transition: transform 0.15s ease, box-shadow 0.2s ease;
+}
+
+.owned-decision-close:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 12px 24px rgba(15, 23, 42, 0.3);
+}
+
+.owned-decision-close:focus-visible {
+    outline: 2px solid rgba(96, 165, 250, 0.8);
+    outline-offset: 2px;
 }
 
 


### PR DESCRIPTION
## Summary
- add an accessible close button to the kiosk session header so users can exit to the idle screen
- include a close control on the owned-locker decision overlay and ensure it returns to idle
- style the new overlay control to match existing kiosk UI polish
- temporarily remove the "Eşyamı almak için aç" button from the owned-locker decision screen while we revisit the flow

## Testing
- npm run build --workspace=app/kiosk

------
https://chatgpt.com/codex/tasks/task_e_68cc31e4bcec8329a764ad43da1d449c