### PR TITLE
feat(lockers): add configurable auto-release service

### DIFF
--- a/shared/services/__tests__/locker-auto-release.test.ts
+++ b/shared/services/__tests__/locker-auto-release.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { DatabaseConnection } from '../../database/connection';
+import { LockerStateManager } from '../locker-state-manager';
+import { EventType } from '../../types/core-entities';
+
+const TABLE_LOCKERS_SQL = `
+  CREATE TABLE lockers (
+    kiosk_id TEXT NOT NULL,
+    id INTEGER NOT NULL,
+    status TEXT NOT NULL DEFAULT 'Free',
+    owner_type TEXT,
+    owner_key TEXT,
+    reserved_at DATETIME,
+    owned_at DATETIME,
+    version INTEGER NOT NULL DEFAULT 1,
+    is_vip BOOLEAN NOT NULL DEFAULT 0,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (kiosk_id, id)
+  )
+`;
+
+const TABLE_EVENTS_SQL = `
+  CREATE TABLE events (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    timestamp DATETIME DEFAULT CURRENT_TIMESTAMP,
+    kiosk_id TEXT NOT NULL,
+    locker_id INTEGER,
+    event_type TEXT NOT NULL,
+    rfid_card TEXT,
+    device_id TEXT,
+    staff_user TEXT,
+    details TEXT
+  )
+`;
+
+describe('LockerStateManager auto-release', () => {
+  let db: DatabaseConnection;
+  let stateManager: LockerStateManager;
+
+  beforeEach(async () => {
+    DatabaseConnection.resetInstance(':memory:');
+    db = DatabaseConnection.getInstance(':memory:');
+    await db.waitForInitialization();
+    await db.exec(TABLE_LOCKERS_SQL);
+    await db.exec(TABLE_EVENTS_SQL);
+  });
+
+  afterEach(async () => {
+    if (stateManager) {
+      await stateManager.shutdown();
+    }
+    DatabaseConnection.resetInstance(':memory:');
+  });
+
+  it('releases lockers exceeding the auto-release threshold', async () => {
+    stateManager = new LockerStateManager(db, {
+      autoReleaseHoursOverride: 0.001, // ~3.6 seconds
+      autoReleaseCheckIntervalMs: 0
+    });
+
+    const now = Date.now();
+    const expiredTimestamp = new Date(now - 60 * 60 * 1000).toISOString(); // 1 hour ago
+    const recentTimestamp = new Date(now - 1000).toISOString(); // 1 second ago
+
+    await db.run(
+      `INSERT INTO lockers (kiosk_id, id, status, owner_type, owner_key, reserved_at, owned_at, version, is_vip, created_at, updated_at)
+       VALUES (?, ?, 'Owned', 'rfid', ?, ?, ?, 1, 0, datetime('now'), datetime('now'))`,
+      ['kiosk-1', 1, 'card-expired', expiredTimestamp, expiredTimestamp]
+    );
+
+    await db.run(
+      `INSERT INTO lockers (kiosk_id, id, status, owner_type, owner_key, reserved_at, owned_at, version, is_vip, created_at, updated_at)
+       VALUES (?, ?, 'Owned', 'rfid', ?, ?, ?, 1, 0, datetime('now'), datetime('now'))`,
+      ['kiosk-1', 2, 'card-fresh', recentTimestamp, recentTimestamp]
+    );
+
+    const cleaned = await stateManager.cleanupExpiredReservations();
+    expect(cleaned).toBe(1);
+
+    const releasedLocker = await stateManager.getLocker('kiosk-1', 1);
+    expect(releasedLocker?.status).toBe('Free');
+    expect(releasedLocker?.owner_key).toBeNull();
+    expect(releasedLocker?.owner_type).toBeNull();
+
+    const freshLocker = await stateManager.getLocker('kiosk-1', 2);
+    expect(freshLocker?.status).toBe('Owned');
+    expect(freshLocker?.owner_key).toBe('card-fresh');
+
+    const events = await db.all<any>(
+      `SELECT event_type, details FROM events WHERE kiosk_id = ? ORDER BY id`,
+      ['kiosk-1']
+    );
+    expect(events).toHaveLength(1);
+    expect(events[0].event_type).toBe(EventType.AUTO_RELEASE);
+
+    const details = JSON.parse(events[0].details);
+    expect(details.triggered_by).toBe('auto_release');
+    expect(details.owner_key).toBe('card-expired');
+  });
+
+  it('skips cleanup when auto-release is disabled', async () => {
+    await db.run(
+      `INSERT INTO lockers (kiosk_id, id, status, owner_type, owner_key, reserved_at, owned_at, version, is_vip, created_at, updated_at)
+       VALUES (?, ?, 'Owned', 'rfid', ?, datetime('now'), datetime('now'), 1, 0, datetime('now'), datetime('now'))`,
+      ['kiosk-1', 1, 'card-disabled']
+    );
+
+    stateManager = new LockerStateManager(db, {
+      autoReleaseHoursOverride: null
+    });
+
+    const cleaned = await stateManager.cleanupExpiredReservations();
+    expect(cleaned).toBe(0);
+
+    const locker = await stateManager.getLocker('kiosk-1', 1);
+    expect(locker?.status).toBe('Owned');
+  });
+});

--- a/shared/services/config-manager.ts
+++ b/shared/services/config-manager.ts
@@ -134,6 +134,7 @@ export class ConfigManager {
     return {
       BULK_INTERVAL_MS: config.lockers.bulk_operation_interval_ms,
       RESERVE_TTL_SECONDS: config.lockers.reserve_ttl_seconds,
+      AUTO_RELEASE_HOURS: config.lockers.auto_release_hours,
       OPEN_PULSE_MS: config.hardware.modbus.pulse_duration_ms,
       OPEN_BURST_SECONDS: config.hardware.modbus.burst_duration_seconds,
       OPEN_BURST_INTERVAL_MS: config.hardware.modbus.burst_interval_ms,
@@ -348,6 +349,16 @@ export class ConfigManager {
         warnings.push('Reserve TTL less than 30 seconds may cause user experience issues');
       }
 
+      if (config.lockers.auto_release_hours !== undefined) {
+        if (typeof config.lockers.auto_release_hours !== 'number' || isNaN(config.lockers.auto_release_hours)) {
+          errors.push('Auto release hours must be a numeric value');
+        } else if (config.lockers.auto_release_hours <= 0) {
+          warnings.push('Auto release hours is non-positive; automatic cleanup will be disabled');
+        } else if (config.lockers.auto_release_hours < 0.5) {
+          warnings.push('Auto release hours less than 0.5 may release lockers too aggressively');
+        }
+      }
+
       if (config.hardware.modbus.pulse_duration_ms < 100 || config.hardware.modbus.pulse_duration_ms > 1000) {
         warnings.push('Modbus pulse duration outside recommended range (100-1000ms)');
       }
@@ -497,6 +508,7 @@ export class ConfigManager {
       lockers: {
         total_count: 16,
         reserve_ttl_seconds: 90,
+        auto_release_hours: 24,
         offline_threshold_seconds: 30,
         bulk_operation_interval_ms: 300,
         master_lockout_fails: 5,

--- a/shared/types/core-entities.ts
+++ b/shared/types/core-entities.ts
@@ -114,6 +114,7 @@ export enum EventType {
   RFID_RELEASE = 'rfid_release',
   QR_ASSIGN = 'qr_assign',
   QR_RELEASE = 'qr_release',
+  AUTO_RELEASE = 'auto_release',
   
   // Staff events
   STAFF_OPEN = 'staff_open',

--- a/shared/types/system-config.ts
+++ b/shared/types/system-config.ts
@@ -7,6 +7,7 @@ export interface SystemConfig {
   // Locker operation timing
   BULK_INTERVAL_MS: number; // Default: 300
   RESERVE_TTL_SECONDS: number; // Default: 90
+  AUTO_RELEASE_HOURS?: number; // Optional: auto-release threshold in hours
   OPEN_PULSE_MS: number; // Default: 400
   OPEN_BURST_SECONDS: number; // Default: 10
   OPEN_BURST_INTERVAL_MS: number; // Default: 2000


### PR DESCRIPTION
## Summary
- restore locker auto-release by scheduling cleanup based on the lockers.auto_release_hours configuration
- record automatic releases with a dedicated event type and include reason metadata in release logs
- extend config validation/defaults and add focused tests that verify expired lockers are freed while fresh assignments persist

## Testing
- npx vitest --run shared/services/__tests__/locker-auto-release.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68cdbe9e2ef08329a8992a994919befe