### PR TITLE
Implement recent locker reassignment rule

### DIFF
--- a/app/panel/src/views/assignment-settings.html
+++ b/app/panel/src/views/assignment-settings.html
@@ -76,6 +76,50 @@
             cursor: pointer;
         }
 
+        .field-group {
+            margin-top: 24px;
+            display: flex;
+            flex-direction: column;
+            gap: 12px;
+        }
+
+        .field-group label {
+            font-weight: 600;
+            display: flex;
+            align-items: center;
+            gap: 8px;
+        }
+
+        .field-group small {
+            color: #5b667d;
+            line-height: 1.5;
+        }
+
+        .min-hours-control {
+            display: flex;
+            gap: 12px;
+            flex-wrap: wrap;
+            align-items: center;
+        }
+
+        .min-hours-control input[type="range"] {
+            flex: 1 1 220px;
+        }
+
+        .min-hours-control input[type="number"] {
+            width: 80px;
+            padding: 6px 10px;
+            border: 1px solid #d0d7ec;
+            border-radius: 6px;
+            font-size: 14px;
+        }
+
+        .min-hours-value {
+            font-weight: 600;
+            color: #1f2a44;
+            min-width: 110px;
+        }
+
         .actions {
             display: flex;
             justify-content: flex-end;
@@ -148,6 +192,19 @@
                 Otomatik dolap ata ve aç
             </label>
         </div>
+        <div class="field-group">
+            <label for="recentHolderSlider">
+                ⏱️ Son kullanılan dolabı önceliklendir
+            </label>
+            <small>
+                Kartın bir dolabı en az bu kadar süre tuttuğu son 24 saat içinde tekrar gelirse aynı dolabı otomatik atar. 0 saat seçildiğinde kural devre dışı kalır.
+            </small>
+            <div class="min-hours-control">
+                <input id="recentHolderSlider" type="range" min="0" max="24" step="0.5" value="2">
+                <input id="recentHolderNumber" type="number" min="0" max="24" step="0.5" value="2">
+                <span id="recentHolderDisplay" class="min-hours-value">2 saat</span>
+            </div>
+        </div>
         <div class="actions">
             <button type="button" class="btn-secondary" onclick="loadSettings()">Yenile</button>
             <button type="button" class="btn-primary" onclick="saveSettings()">Kaydet</button>
@@ -159,6 +216,7 @@
 <script>
     let csrfToken = null;
     let currentDefaultMode = 'manual';
+    let currentMinHeldHours = 2;
     let isSaving = false;
 
     function getSaveButton() {
@@ -207,7 +265,9 @@
             }
 
             const defaultMode = result.default_mode || 'manual';
+            const minHours = typeof result.recent_holder_min_hours === 'number' ? result.recent_holder_min_hours : 0;
             applyDefaultMode(defaultMode);
+            applyMinHeldHours(minHours);
         } catch (error) {
             statusEl.className = 'status error';
             statusEl.textContent = `Ayarlar yüklenemedi: ${error instanceof Error ? error.message : error}`;
@@ -222,6 +282,29 @@
                 input.checked = input.value === currentDefaultMode;
             }
         });
+    }
+
+    function applyMinHeldHours(value) {
+        const sanitized = typeof value === 'number' && !Number.isNaN(value)
+            ? Math.min(24, Math.max(0, value))
+            : 0;
+        currentMinHeldHours = Math.round(sanitized * 2) / 2;
+
+        const slider = document.getElementById('recentHolderSlider');
+        const numberInput = document.getElementById('recentHolderNumber');
+        const display = document.getElementById('recentHolderDisplay');
+
+        if (slider instanceof HTMLInputElement) {
+            slider.value = currentMinHeldHours.toString();
+        }
+        if (numberInput instanceof HTMLInputElement) {
+            numberInput.value = currentMinHeldHours.toString();
+        }
+        if (display) {
+            display.textContent = currentMinHeldHours === 0
+                ? 'Devre dışı'
+                : `${currentMinHeldHours.toLocaleString('tr-TR')} saat`;
+        }
     }
 
     async function saveSettings() {
@@ -262,7 +345,8 @@
                 },
                 credentials: 'same-origin',
                 body: JSON.stringify({
-                    default_mode: selectedDefault.value
+                    default_mode: selectedDefault.value,
+                    recent_holder_min_hours: currentMinHeldHours
                 })
             });
 
@@ -312,6 +396,23 @@
                     return;
                 }
                 applyDefaultMode(target.value);
+            });
+        }
+
+        const slider = document.getElementById('recentHolderSlider');
+        const numberInput = document.getElementById('recentHolderNumber');
+
+        if (slider instanceof HTMLInputElement) {
+            slider.addEventListener('input', event => {
+                const value = parseFloat((event.target as HTMLInputElement).value);
+                applyMinHeldHours(value);
+            });
+        }
+
+        if (numberInput instanceof HTMLInputElement) {
+            numberInput.addEventListener('input', event => {
+                const value = parseFloat((event.target as HTMLInputElement).value);
+                applyMinHeldHours(value);
             });
         }
     });

--- a/shared/services/__tests__/config-manager.test.ts
+++ b/shared/services/__tests__/config-manager.test.ts
@@ -502,7 +502,8 @@ describe('ConfigManager', () => {
       await configManager.setKioskAssignmentConfig(
         {
           default_mode: 'manual',
-          per_kiosk: {}
+          per_kiosk: {},
+          recent_holder_min_hours: 1.5
         },
         'test-user',
         'Reset kiosk assignment defaults'
@@ -515,10 +516,12 @@ describe('ConfigManager', () => {
       const savedConfig = JSON.parse(lastWrite![1] as string) as CompleteSystemConfig;
       expect(savedConfig.services.kiosk.assignment?.default_mode).toBe('manual');
       expect(savedConfig.services.kiosk.assignment?.per_kiosk).toEqual({});
+      expect(savedConfig.services.kiosk.assignment?.recent_holder_min_hours).toBe(1.5);
 
       const updatedConfig = configManager.getConfiguration();
       expect(updatedConfig.services.kiosk.assignment?.default_mode).toBe('manual');
       expect(updatedConfig.services.kiosk.assignment?.per_kiosk).toEqual({});
+      expect(updatedConfig.services.kiosk.assignment?.recent_holder_min_hours).toBe(1.5);
     });
   });
 

--- a/shared/services/__tests__/locker-state-manager.test.ts
+++ b/shared/services/__tests__/locker-state-manager.test.ts
@@ -246,7 +246,7 @@ describe('LockerStateManager', () => {
 
     it('should release Owned locker', async () => {
       const result = await stateManager.releaseLocker('kiosk-1', 2, 'card-456');
-      
+
       expect(result).toBe(true);
 
       const locker = await stateManager.getLocker('kiosk-1', 2);
@@ -254,6 +254,36 @@ describe('LockerStateManager', () => {
       expect(locker?.owner_type).toBeNull();
       expect(locker?.owner_key).toBeNull();
       expect(locker?.owned_at).toBeNull();
+    });
+
+    it('should log held duration metadata on release', async () => {
+      vi.useFakeTimers();
+      try {
+        const now = new Date('2024-01-01T12:00:00.000Z');
+        vi.setSystemTime(now);
+
+        const heldStart = new Date(now.getTime() - 3 * 60 * 60 * 1000);
+        await db.run(
+          `UPDATE lockers SET owned_at = ?, reserved_at = ? WHERE kiosk_id = ? AND id = ?`,
+          [heldStart.toISOString(), heldStart.toISOString(), 'kiosk-1', 2]
+        );
+
+        const result = await stateManager.releaseLocker('kiosk-1', 2, 'card-456');
+        expect(result).toBe(true);
+
+        const event = await db.get(
+          `SELECT * FROM events WHERE kiosk_id = ? AND locker_id = ? AND event_type = ? ORDER BY id DESC LIMIT 1`,
+          ['kiosk-1', 2, EventType.RFID_RELEASE]
+        ) as any;
+
+        const details = JSON.parse(event.details as string);
+        expect(details.released_at).toBe(now.toISOString());
+        expect(details.held_started_at).toBe(heldStart.toISOString());
+        expect(details.held_duration_minutes).toBe(180);
+        expect(details.held_duration_hours).toBeCloseTo(3, 5);
+      } finally {
+        vi.useRealTimers();
+      }
     });
 
     it('should reject release with wrong owner key', async () => {
@@ -279,6 +309,60 @@ describe('LockerStateManager', () => {
       expect(details.owner_type).toBe('rfid');
       expect(details.owner_key).toBe('card-123');
       expect(details.previous_status).toBe('Owned');
+      expect(events[0].rfid_card).toBe('card-123');
+    });
+  });
+
+  describe('getRecentLockerReleaseForCard', () => {
+    it('returns recent release details within the lookback window', async () => {
+      vi.useFakeTimers();
+      try {
+        const now = new Date('2024-03-10T10:00:00.000Z');
+        vi.setSystemTime(now);
+
+        const heldStart = new Date(now.getTime() - 4 * 60 * 60 * 1000);
+        await db.run(`
+          INSERT INTO lockers (kiosk_id, id, status, owner_type, owner_key, reserved_at, owned_at, version, is_vip)
+          VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+        `, ['kiosk-2', 7, 'Owned', 'rfid', 'card-recent', heldStart.toISOString(), heldStart.toISOString(), 1, 0]);
+
+        const released = await stateManager.releaseLocker('kiosk-2', 7, 'card-recent');
+        expect(released).toBe(true);
+
+        const info = await stateManager.getRecentLockerReleaseForCard('kiosk-2', 'card-recent', 24);
+        expect(info).not.toBeNull();
+        expect(info?.lockerId).toBe(7);
+        expect(info?.heldDurationMinutes).toBe(240);
+        expect(info?.heldDurationHours).toBeCloseTo(4, 5);
+        expect(info?.releasedAt.toISOString()).toBe(now.toISOString());
+        expect(info?.heldStartedAt?.toISOString()).toBe(heldStart.toISOString());
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('returns null when no release falls within the requested window', async () => {
+      vi.useFakeTimers();
+      try {
+        const earlier = new Date('2024-03-05T08:00:00.000Z');
+        vi.setSystemTime(earlier);
+
+        const heldStart = new Date(earlier.getTime() - 60 * 60 * 1000);
+        await db.run(`
+          INSERT INTO lockers (kiosk_id, id, status, owner_type, owner_key, reserved_at, owned_at, version, is_vip)
+          VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+        `, ['kiosk-3', 9, 'Owned', 'rfid', 'card-old', heldStart.toISOString(), heldStart.toISOString(), 1, 0]);
+
+        await stateManager.releaseLocker('kiosk-3', 9, 'card-old');
+
+        const now = new Date('2024-03-10T08:00:00.000Z');
+        vi.setSystemTime(now);
+
+        const info = await stateManager.getRecentLockerReleaseForCard('kiosk-3', 'card-old', 24);
+        expect(info).toBeNull();
+      } finally {
+        vi.useRealTimers();
+      }
     });
   });
 

--- a/shared/services/config-manager.ts
+++ b/shared/services/config-manager.ts
@@ -17,6 +17,8 @@ import { EventType } from '../types/core-entities';
 import { EventRepository } from '../database/event-repository';
 import { DatabaseManager } from '../database/database-manager';
 
+const DEFAULT_RECENT_HOLDER_MIN_HOURS = 2;
+
 /**
  * Manages the system's configuration, providing a centralized point for loading,
  * validating, accessing, and updating configuration settings. It supports loading from a JSON file,
@@ -351,6 +353,28 @@ export class ConfigManager {
     }
 
     return 'manual';
+  }
+
+  getRecentHolderMinHours(): number {
+    try {
+      const config = this.getConfiguration();
+      const assignment = config.services?.kiosk?.assignment;
+
+      if (assignment) {
+        if (typeof assignment.recent_holder_min_hours === 'number') {
+          return this.sanitizeRecentHolderMinHours(assignment.recent_holder_min_hours);
+        }
+
+        return DEFAULT_RECENT_HOLDER_MIN_HOURS;
+      }
+    } catch (error) {
+      console.warn(
+        `Failed to read recent holder threshold, defaulting to ${DEFAULT_RECENT_HOLDER_MIN_HOURS}:`,
+        error
+      );
+    }
+
+    return DEFAULT_RECENT_HOLDER_MIN_HOURS;
   }
 
   /**
@@ -739,6 +763,7 @@ export class ConfigManager {
           assignment: {
             default_mode: 'manual',
             per_kiosk: {},
+            recent_holder_min_hours: DEFAULT_RECENT_HOLDER_MIN_HOURS
           }
         },
         panel: {
@@ -1007,8 +1032,20 @@ export class ConfigManager {
 
     return {
       default_mode: defaultMode,
-      per_kiosk: sanitizedPerKiosk
+      per_kiosk: sanitizedPerKiosk,
+      recent_holder_min_hours: this.sanitizeRecentHolderMinHours(
+        assignment.recent_holder_min_hours ?? DEFAULT_RECENT_HOLDER_MIN_HOURS
+      )
     };
+  }
+
+  private sanitizeRecentHolderMinHours(value: unknown): number {
+    if (typeof value !== 'number' || Number.isNaN(value) || !Number.isFinite(value)) {
+      return 0;
+    }
+
+    const clamped = Math.min(24, Math.max(0, value));
+    return Math.round(clamped * 2) / 2;
   }
 
   /**

--- a/shared/types/system-config.ts
+++ b/shared/types/system-config.ts
@@ -69,6 +69,7 @@ export type LockerAssignmentMode = 'manual' | 'automatic';
 export interface KioskAssignmentConfig {
   default_mode: LockerAssignmentMode;
   per_kiosk?: Record<string, LockerAssignmentMode>;
+  recent_holder_min_hours?: number;
 }
 
 export interface ServiceConfig {


### PR DESCRIPTION
## Summary
- add configurable recent-holder threshold to kiosk assignment settings and ConfigManager defaults
- log release durations and expose recent release lookups for RFID cards to support reassignment
- reassign recently held lockers when available and update panel UI plus tests for the new behaviour

## Testing
- npm run test --workspace=shared
- npm run test --workspace=app/kiosk -- src/services/__tests__/rfid-user-flow.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68d08effffdc83298bf69f22b85203a6