### PR TITLE
Disable locker open action and document regression

### DIFF
--- a/analysis-reports/locker-fryer-deadly-code.md
+++ b/analysis-reports/locker-fryer-deadly-code.md
@@ -1,0 +1,14 @@
+# Locker Fryer Deadly Code Report
+
+## Summary
+A regression in the admin panel introduced a debugging shim around `openSelectedLockers()`. The shim reassigns `window.openSelectedLockers` and transparently invokes the original implementation. When the view script is re-evaluated (e.g., during partial reloads triggered by panel navigation), the shim wraps the already wrapped function. On the next button press each wrapper invokes the previously wrapped version, eventually re-entering the newest shim again. This creates a tight recursion loop that repeatedly reissues open commands until the page is reloaded.
+
+## Impact
+- Operators see lockers repeatedly receive open commands without further interaction.
+- Command queue noise and hardware wear from repeated relay activations.
+- Manual mitigation required via hard refresh or server intervention.
+
+## Fix
+- Removed the shim so `openSelectedLockers()` is no longer recursively wrapped.
+- Removed the "Open" action button from the panel and replaced it with a warning banner while the backend loop is investigated.
+- Updated `updateSelectedCount()` so it no longer references the removed button.

--- a/app/panel/src/views/lockers.html
+++ b/app/panel/src/views/lockers.html
@@ -970,9 +970,9 @@
 
         <!-- Actions -->
         <div class="actions">
-            <button class="btn btn-primary" onclick="openSelectedLockers()" id="open-btn" disabled>
-                Select lockers first
-            </button>
+            <div class="alert" role="alert" style="background: #fff3cd; color: #856404; border: 1px solid #ffeeba; padding: 12px 16px; border-radius: 6px;">
+                🔒 Locker opening has been temporarily disabled while we investigate a command loop issue.
+            </div>
             <button class="btn btn-success" onclick="releaseSelectedLockers()" id="release-btn" disabled>
                 Select lockers first
             </button>
@@ -2695,33 +2695,28 @@
 
         function updateSelectedCount() {
             const count = selectedLockers.size;
-            
-            const openBtn = document.getElementById('open-btn');
+
             const releaseBtn = document.getElementById('release-btn');
             const refreshBtn = document.getElementById('refresh-btn');
             const blockBtn = document.getElementById('block-btn');
             const unblockBtn = document.getElementById('unblock-btn');
-            
+
             if (count === 0) {
-                openBtn.innerHTML = 'Select lockers first';
                 releaseBtn.innerHTML = 'Select lockers first';
                 refreshBtn.innerHTML = 'Select lockers first';
                 blockBtn.innerHTML = 'Select lockers first';
                 unblockBtn.innerHTML = 'Select lockers first';
-                
-                openBtn.disabled = true;
+
                 releaseBtn.disabled = true;
                 refreshBtn.disabled = true;
                 blockBtn.disabled = true;
                 unblockBtn.disabled = true;
             } else {
-                openBtn.innerHTML = `Aç ${count} dolap${count > 1 ? '' : ''}`;
                 releaseBtn.innerHTML = `Serbest Bırak ${count} dolap${count > 1 ? '' : ''}`;
                 refreshBtn.innerHTML = `Yenile ${count} dolap${count > 1 ? '' : ''}`;
                 blockBtn.innerHTML = `Blokla ${count} dolap${count > 1 ? '' : ''}`;
                 unblockBtn.innerHTML = `Blok Kaldır ${count} dolap${count > 1 ? '' : ''}`;
-                
-                openBtn.disabled = false;
+
                 releaseBtn.disabled = false;
                 refreshBtn.disabled = false;
                 blockBtn.disabled = false;
@@ -3319,29 +3314,6 @@
     console.log('🔧 Enhanced button logging initialized');
     
     // Override button functions with logging
-    const originalOpenSelectedLockers = window.openSelectedLockers;
-    window.openSelectedLockers = function() {
-        console.log('🔓 openSelectedLockers called');
-        console.log('📊 Selected lockers count:', selectedLockers.size);
-        console.log('📊 Selected lockers:', Array.from(selectedLockers));
-        console.log('📊 CSRF token:', csrfToken ? 'present' : 'missing');
-        console.log('📊 Current user:', currentUser);
-        
-        if (selectedLockers.size === 0) {
-            console.log('⚠️ No lockers selected - function will return early');
-            return;
-        }
-        
-        try {
-            const result = originalOpenSelectedLockers.call(this);
-            console.log('✅ openSelectedLockers completed');
-            return result;
-        } catch (error) {
-            console.error('❌ openSelectedLockers failed:', error);
-            throw error;
-        }
-    };
-    
     const originalBlockSelectedLockers = window.blockSelectedLockers;
     window.blockSelectedLockers = function() {
         console.log('🚫 blockSelectedLockers called');


### PR DESCRIPTION
## Summary
- remove the panel "Open" action button and replace it with a warning banner while the command-loop issue is investigated
- stop wrapping `openSelectedLockers` with the debugging shim that caused the repeated command dispatch
- adjust the selection counter to avoid referencing the removed button and document the regression in a new Locker Fryer report

## Testing
- npm run build:panel

------
https://chatgpt.com/codex/tasks/task_e_68d12b65669483299346a3fcf34963d3