### PR TITLE
Add panel control for manual locker display limit

### DIFF
--- a/app/kiosk/src/services/__tests__/rfid-user-flow-vip.test.ts
+++ b/app/kiosk/src/services/__tests__/rfid-user-flow-vip.test.ts
@@ -18,7 +18,11 @@ describe('RfidUserFlow VIP Locker Handling', () => {
   let rfidUserFlow: RfidUserFlow;
   let mockLockerStateManager: vi.Mocked<LockerStateManager>;
   let mockModbusController: vi.Mocked<ModbusController>;
-  let mockConfigManager: { initialize: ReturnType<typeof vi.fn>; getKioskAssignmentMode: ReturnType<typeof vi.fn> };
+  let mockConfigManager: {
+    initialize: ReturnType<typeof vi.fn>;
+    getKioskAssignmentMode: ReturnType<typeof vi.fn>;
+    getMaxAvailableLockersDisplay: ReturnType<typeof vi.fn>;
+  };
 
   const config = {
     kiosk_id: 'test-kiosk',
@@ -40,7 +44,8 @@ describe('RfidUserFlow VIP Locker Handling', () => {
 
     mockConfigManager = {
       initialize: vi.fn().mockResolvedValue(undefined),
-      getKioskAssignmentMode: vi.fn().mockReturnValue('manual' as LockerAssignmentMode)
+      getKioskAssignmentMode: vi.fn().mockReturnValue('manual' as LockerAssignmentMode),
+      getMaxAvailableLockersDisplay: vi.fn().mockReturnValue(10)
     };
 
     rfidUserFlow = new RfidUserFlow(

--- a/app/kiosk/src/services/__tests__/rfid-user-flow.integration.test.ts
+++ b/app/kiosk/src/services/__tests__/rfid-user-flow.integration.test.ts
@@ -14,6 +14,7 @@ describe('RfidUserFlow integration - recent holder reassignment', () => {
     initialize: ReturnType<typeof vi.fn>;
     getKioskAssignmentMode: ReturnType<typeof vi.fn>;
     getRecentHolderMinHours: ReturnType<typeof vi.fn>;
+    getMaxAvailableLockersDisplay: ReturnType<typeof vi.fn>;
   };
 
   const kioskId = 'integration-kiosk';
@@ -76,7 +77,8 @@ describe('RfidUserFlow integration - recent holder reassignment', () => {
     configManager = {
       initialize: vi.fn().mockResolvedValue(undefined),
       getKioskAssignmentMode: vi.fn().mockReturnValue('automatic'),
-      getRecentHolderMinHours: vi.fn().mockReturnValue(2)
+      getRecentHolderMinHours: vi.fn().mockReturnValue(2),
+      getMaxAvailableLockersDisplay: vi.fn().mockReturnValue(10)
     };
   });
 

--- a/app/kiosk/src/services/__tests__/rfid-user-flow.test.ts
+++ b/app/kiosk/src/services/__tests__/rfid-user-flow.test.ts
@@ -23,6 +23,7 @@ describe('RfidUserFlow', () => {
     initialize: ReturnType<typeof vi.fn>;
     getKioskAssignmentMode: ReturnType<typeof vi.fn>;
     getRecentHolderMinHours: ReturnType<typeof vi.fn>;
+    getMaxAvailableLockersDisplay: ReturnType<typeof vi.fn>;
   };
 
   const mockKioskId = 'test-kiosk-001';
@@ -32,7 +33,8 @@ describe('RfidUserFlow', () => {
     return {
       initialize: vi.fn().mockResolvedValue(undefined),
       getKioskAssignmentMode: vi.fn().mockReturnValue(mode),
-      getRecentHolderMinHours: vi.fn().mockReturnValue(0)
+      getRecentHolderMinHours: vi.fn().mockReturnValue(0),
+      getMaxAvailableLockersDisplay: vi.fn().mockReturnValue(10)
     };
   }
 
@@ -159,6 +161,7 @@ describe('RfidUserFlow', () => {
 
       mockLockerStateManager.checkExistingOwnership.mockResolvedValue(null);
       mockLockerStateManager.getAvailableLockers.mockResolvedValue(manyLockers);
+      mockConfigManager.getMaxAvailableLockersDisplay.mockReturnValue(8);
 
       const scanEvent: RfidScanEvent = {
         card_id: mockCardId,
@@ -169,11 +172,13 @@ describe('RfidUserFlow', () => {
       const result = await rfidUserFlow.handleCardScanned(scanEvent);
 
       expect(result.success).toBe(true);
-      expect(result.available_lockers).toHaveLength(config.max_available_lockers_display);
+      expect(mockConfigManager.getMaxAvailableLockersDisplay).toHaveBeenCalled();
+      expect(result.available_lockers).toHaveLength(8);
       expect(result.assignment_mode).toBe('manual');
       expect(result.auto_assigned).toBe(false);
       expect(result.available_lockers![0].id).toBe(1);
-      expect(result.available_lockers![9].id).toBe(10);
+      expect(result.available_lockers![7].id).toBe(8);
+      expect(rfidUserFlow.getConfig().max_available_lockers_display).toBe(8);
     });
 
     it('should emit show_available_lockers event', async () => {

--- a/app/panel/src/views/assignment-settings.html
+++ b/app/panel/src/views/assignment-settings.html
@@ -95,6 +95,29 @@
             line-height: 1.5;
         }
 
+        .manual-only {
+            margin-top: 24px;
+        }
+
+        .manual-only.hidden {
+            display: none;
+        }
+
+        .count-control {
+            display: flex;
+            gap: 12px;
+            align-items: center;
+            flex-wrap: wrap;
+        }
+
+        .count-control input[type="number"] {
+            width: 100px;
+            padding: 6px 10px;
+            border: 1px solid #d0d7ec;
+            border-radius: 6px;
+            font-size: 14px;
+        }
+
         .min-hours-control {
             display: flex;
             gap: 12px;
@@ -218,6 +241,20 @@
                 <span id="openOnlyWindowDisplay" class="min-hours-value">1 saat</span>
             </div>
         </div>
+        <div id="manualOnlyFields" class="manual-only hidden">
+            <div class="field-group">
+                <label for="manualLockerLimitInput">
+                    📋 Manuel seçim listesi sınırı
+                </label>
+                <small>
+                    Manuel atama ekranında listelenecek maksimum boş dolap sayısı. Değer, sadece manuel mod aktifken uygulanır.
+                </small>
+                <div class="count-control">
+                    <input id="manualLockerLimitInput" type="number" min="1" max="60" step="1" value="10">
+                    <span id="manualLockerLimitDisplay" class="min-hours-value">10 dolap</span>
+                </div>
+            </div>
+        </div>
         <div class="actions">
             <button type="button" class="btn-secondary" onclick="loadSettings()">Yenile</button>
             <button type="button" class="btn-primary" onclick="saveSettings()">Kaydet</button>
@@ -231,7 +268,10 @@
     let currentDefaultMode = 'manual';
     let currentMinHeldHours = 2;
     let currentOpenOnlyWindowHours = 1;
+    let currentManualDisplayLimit = 10;
     let isSaving = false;
+    const MANUAL_LIMIT_MIN = 1;
+    const MANUAL_LIMIT_MAX = 60;
 
     function getSaveButton() {
         return document.querySelector('button.btn-primary');
@@ -281,9 +321,13 @@
             const defaultMode = result.default_mode || 'manual';
             const minHours = typeof result.recent_holder_min_hours === 'number' ? result.recent_holder_min_hours : 0;
             const openOnlyWindow = typeof result.open_only_window_hours === 'number' ? result.open_only_window_hours : 1;
+            const manualLimit = typeof result.max_available_lockers_display === 'number'
+                ? result.max_available_lockers_display
+                : MANUAL_LIMIT_MIN;
             applyDefaultMode(defaultMode);
             applyMinHeldHours(minHours);
             applyOpenOnlyWindowHours(openOnlyWindow);
+            applyManualDisplayLimit(manualLimit);
         } catch (error) {
             statusEl.className = 'status error';
             statusEl.textContent = `Ayarlar yüklenemedi: ${error instanceof Error ? error.message : error}`;
@@ -298,6 +342,7 @@
                 input.checked = input.value === currentDefaultMode;
             }
         });
+        updateManualOptionsVisibility();
     }
 
     function formatHourValue(value) {
@@ -310,6 +355,43 @@
             maximumFractionDigits: 1
         });
         return `${display} saat`;
+    }
+
+    function updateManualOptionsVisibility() {
+        const manualSection = document.getElementById('manualOnlyFields');
+        if (!manualSection) {
+            return;
+        }
+
+        if (currentDefaultMode === 'manual') {
+            manualSection.classList.remove('hidden');
+        } else {
+            manualSection.classList.add('hidden');
+        }
+    }
+
+    function formatLockerCount(value) {
+        const normalized = Number.isFinite(value)
+            ? Math.max(MANUAL_LIMIT_MIN, Math.min(MANUAL_LIMIT_MAX, Math.round(value)))
+            : MANUAL_LIMIT_MIN;
+        return normalized === 1 ? '1 dolap' : `${normalized} dolap`;
+    }
+
+    function applyManualDisplayLimit(value) {
+        const sanitized = typeof value === 'number' && !Number.isNaN(value)
+            ? Math.max(MANUAL_LIMIT_MIN, Math.min(MANUAL_LIMIT_MAX, Math.round(value)))
+            : MANUAL_LIMIT_MIN;
+        currentManualDisplayLimit = sanitized;
+
+        const numberInput = document.getElementById('manualLockerLimitInput');
+        const display = document.getElementById('manualLockerLimitDisplay');
+
+        if (numberInput instanceof HTMLInputElement) {
+            numberInput.value = currentManualDisplayLimit.toString();
+        }
+        if (display) {
+            display.textContent = formatLockerCount(currentManualDisplayLimit);
+        }
     }
 
     function applyMinHeldHours(value) {
@@ -396,7 +478,8 @@
                 body: JSON.stringify({
                     default_mode: selectedDefault.value,
                     recent_holder_min_hours: currentMinHeldHours,
-                    open_only_window_hours: currentOpenOnlyWindowHours
+                    open_only_window_hours: currentOpenOnlyWindowHours,
+                    max_available_lockers_display: currentManualDisplayLimit
                 })
             });
 
@@ -453,6 +536,7 @@
         const numberInput = document.getElementById('recentHolderNumber');
         const openOnlySlider = document.getElementById('openOnlyWindowSlider');
         const openOnlyNumber = document.getElementById('openOnlyWindowNumber');
+        const manualLimitInput = document.getElementById('manualLockerLimitInput');
 
         if (slider instanceof HTMLInputElement) {
             slider.addEventListener('input', event => {
@@ -495,6 +579,17 @@
                 }
                 const value = parseFloat(target.value);
                 applyOpenOnlyWindowHours(value);
+            });
+        }
+
+        if (manualLimitInput instanceof HTMLInputElement) {
+            manualLimitInput.addEventListener('input', event => {
+                const target = event.target;
+                if (!(target instanceof HTMLInputElement)) {
+                    return;
+                }
+                const value = parseFloat(target.value);
+                applyManualDisplayLimit(value);
             });
         }
     });

--- a/shared/services/__tests__/config-manager.test.ts
+++ b/shared/services/__tests__/config-manager.test.ts
@@ -504,7 +504,8 @@ describe('ConfigManager', () => {
           default_mode: 'manual',
           per_kiosk: {},
           recent_holder_min_hours: 1.5,
-          open_only_window_hours: 0.75
+          open_only_window_hours: 0.75,
+          max_available_lockers_display: 28
         },
         'test-user',
         'Reset kiosk assignment defaults'
@@ -519,12 +520,14 @@ describe('ConfigManager', () => {
       expect(savedConfig.services.kiosk.assignment?.per_kiosk).toEqual({});
       expect(savedConfig.services.kiosk.assignment?.recent_holder_min_hours).toBe(1.5);
       expect(savedConfig.services.kiosk.assignment?.open_only_window_hours).toBe(0.8);
+      expect(savedConfig.services.kiosk.assignment?.max_available_lockers_display).toBe(28);
 
       const updatedConfig = configManager.getConfiguration();
       expect(updatedConfig.services.kiosk.assignment?.default_mode).toBe('manual');
       expect(updatedConfig.services.kiosk.assignment?.per_kiosk).toEqual({});
       expect(updatedConfig.services.kiosk.assignment?.recent_holder_min_hours).toBe(1.5);
       expect(updatedConfig.services.kiosk.assignment?.open_only_window_hours).toBe(0.8);
+      expect(updatedConfig.services.kiosk.assignment?.max_available_lockers_display).toBe(28);
     });
 
     it('should round recent holder minimum hours to the nearest tenth', async () => {
@@ -556,6 +559,34 @@ describe('ConfigManager', () => {
 
       const updatedConfig = configManager.getConfiguration();
       expect(updatedConfig.services.kiosk.assignment?.open_only_window_hours).toBe(0);
+    });
+
+    it('should clamp manual selection display limit between 1 and 60', async () => {
+      await configManager.setKioskAssignmentConfig(
+        {
+          default_mode: 'manual',
+          per_kiosk: {},
+          max_available_lockers_display: 120
+        },
+        'test-user',
+        'Clamp manual selection upper bound'
+      );
+
+      let updatedConfig = configManager.getConfiguration();
+      expect(updatedConfig.services.kiosk.assignment?.max_available_lockers_display).toBe(60);
+
+      await configManager.setKioskAssignmentConfig(
+        {
+          default_mode: 'manual',
+          per_kiosk: {},
+          max_available_lockers_display: 0
+        },
+        'test-user',
+        'Clamp manual selection lower bound'
+      );
+
+      updatedConfig = configManager.getConfiguration();
+      expect(updatedConfig.services.kiosk.assignment?.max_available_lockers_display).toBe(1);
     });
   });
 

--- a/shared/types/system-config.ts
+++ b/shared/types/system-config.ts
@@ -71,6 +71,7 @@ export interface KioskAssignmentConfig {
   per_kiosk?: Record<string, LockerAssignmentMode>;
   recent_holder_min_hours?: number;
   open_only_window_hours?: number;
+  max_available_lockers_display?: number;
 }
 
 export interface ServiceConfig {


### PR DESCRIPTION
## Summary
- add a max manual locker list size to the kiosk assignment config with validation and defaults
- expose and persist the manual-mode limit through the assignment settings API and Turkish panel UI copy
- have the kiosk RFID flow honour the shared configuration limit and extend the accompanying tests

## Testing
- npm run build:shared
- npm run build:panel
- npm run build:kiosk
- npm run test --workspace=app/kiosk -- src/services/__tests__/rfid-user-flow.test.ts
- npm run build:gateway

------
https://chatgpt.com/codex/tasks/task_e_68d1d96389548329a2d6a2234b4c9643